### PR TITLE
Update public endpoints in JwtAuthFilter

### DIFF
--- a/src/main/java/com/sirha/proyecto_sirha_dosw/config/JwtAuthFilter.java
+++ b/src/main/java/com/sirha/proyecto_sirha_dosw/config/JwtAuthFilter.java
@@ -57,8 +57,6 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         
         // Lista de endpoints públicos que no requieren autenticación
         if (requestPath.equals("/api/auth/login") || 
-            requestPath.equals("/api/auth/register") ||
-            requestPath.equals("/api/usuarios/register") ||
             requestPath.equals("/api/usuarios/login") ||
             requestPath.startsWith("/swagger-ui") ||
             requestPath.startsWith("/v3/api-docs") ||


### PR DESCRIPTION
Removed '/api/auth/register' and '/api/usuarios/register' from public endpoints.